### PR TITLE
Update api endpoint

### DIFF
--- a/libpurecool/dyson.py
+++ b/libpurecool/dyson.py
@@ -21,7 +21,7 @@ from .exceptions import DysonNotLoggedException
 
 _LOGGER = logging.getLogger(__name__)
 
-DYSON_API_URL = "api.cp.dyson.com"
+DYSON_API_URL = "appapi.cp.dyson.com"
 
 
 class DysonAccount:

--- a/tests/test_dyson_account.py
+++ b/tests/test_dyson_account.py
@@ -7,7 +7,7 @@ from libpurecool.dyson_pure_hotcool import DysonPureHotCool
 from libpurecool.dyson import DysonAccount, DysonPureCoolLink, \
     DysonPureHotCoolLink, Dyson360Eye, DysonNotLoggedException
 
-API_HOST='appapi.cp.dyson.com'
+API_HOST = 'appapi.cp.dyson.com'
 
 class MockResponse:
     def __init__(self, json, status_code=200):

--- a/tests/test_dyson_account.py
+++ b/tests/test_dyson_account.py
@@ -7,6 +7,7 @@ from libpurecool.dyson_pure_hotcool import DysonPureHotCool
 from libpurecool.dyson import DysonAccount, DysonPureCoolLink, \
     DysonPureHotCoolLink, Dyson360Eye, DysonNotLoggedException
 
+API_HOST='appapi.cp.dyson.com'
 
 class MockResponse:
     def __init__(self, json, status_code=200):
@@ -18,7 +19,7 @@ class MockResponse:
 
 
 def _mocked_login_post_failed(*args, **kwargs):
-    url = 'https://{0}{1}?{2}={3}'.format('api.cp.dyson.com',
+    url = 'https://{0}{1}?{2}={3}'.format(API_HOST,
                                           '/v1/userregistration/authenticate',
                                           'country',
                                           'language')
@@ -33,7 +34,7 @@ def _mocked_login_post_failed(*args, **kwargs):
 
 
 def _mocked_login_post(*args, **kwargs):
-    url = 'https://{0}{1}?{2}={3}'.format('api.cp.dyson.com',
+    url = 'https://{0}{1}?{2}={3}'.format(API_HOST,
                                           '/v1/userregistration/authenticate',
                                           'country',
                                           'language')
@@ -48,9 +49,9 @@ def _mocked_login_post(*args, **kwargs):
 
 
 def _mocked_list_devices(*args, **kwargs):
-    url = 'https://{0}{1}'.format('api.cp.dyson.com',
+    url = 'https://{0}{1}'.format(API_HOST,
                                   '/v1/provisioningservice/manifest')
-    url_v2 = 'https://{0}{1}'.format('api.cp.dyson.com',
+    url_v2 = 'https://{0}{1}'.format(API_HOST,
                                      '/v2/provisioningservice/manifest')
 
     if args[0] == url:

--- a/tests/test_dyson_account.py
+++ b/tests/test_dyson_account.py
@@ -9,6 +9,7 @@ from libpurecool.dyson import DysonAccount, DysonPureCoolLink, \
 
 API_HOST = 'appapi.cp.dyson.com'
 
+
 class MockResponse:
     def __init__(self, json, status_code=200):
         self._json = json


### PR DESCRIPTION
Today (2020-02-03) I noticed that libpurecool was no longer able to access my Dyson account. Home Assistant was reporting that the dyson integration failed to load, and further investigation revealed that `DysonAccount.login` in libpurecool was failing.

From watching traffic from the Dyson iOS app, the API endpoint appears to have changed to `appapi.cp.dyson.com`. After updating the address locally, libpurecool was able to connect and the dyson integration started working again.