### PR TITLE
Improve C->K conversion accuracy

### DIFF
--- a/libpurecool/const.py
+++ b/libpurecool/const.py
@@ -122,7 +122,7 @@ class HeatTarget:
         """
         if temperature < 1 or temperature > 37:
             raise DITTE(DITTE.CELSIUS, temperature)
-        return str((int(temperature) + 273) * 10)
+        return str(round((temperature + 273) * 10))
 
     @staticmethod
     def fahrenheit(temperature):

--- a/tests/test_libpurecoollink.py
+++ b/tests/test_libpurecoollink.py
@@ -761,6 +761,7 @@ class TestLibPureCoolLink(unittest.TestCase):
 
     def test_heat_target_celsius(self):
         self.assertEqual(HeatTarget.celsius(25), "2980")
+        self.assertEqual(HeatTarget.celsius(25.5), "2985")
 
         with self.assertRaises(DysonInvalidTargetTemperatureException) as ex:
             HeatTarget.celsius(38)


### PR DESCRIPTION
Handle conversions of floating point temperatures. The current code drops the fractional part of a Celsius temperature before making the conversion to Kelvin. This is a problem when converting from F->C->K, because the F->C conversion is likely to end up with a floating point
value. When the fractional part is dropped, multiple F temperatures will end up mapping to the same K temperature.