### PR TITLE
Make the API work with Chinese accounts

### DIFF
--- a/libpurecool/dyson.py
+++ b/libpurecool/dyson.py
@@ -40,6 +40,10 @@ class DysonAccount:
         self._country = country
         self._logged = False
         self._auth = None
+        if country == "CN":
+            self._dyson_api_url = DYSON_API_URL_CN
+        else:
+            self._dyson_api_url = DYSON_API_URL
 
     def login(self):
         """Login to dyson web services."""
@@ -51,13 +55,12 @@ class DysonAccount:
             "Email": self._email,
             "Password": self._password
         }
-        if self._country == "CN":
-            self.DYSON_API_URL = DYSON_API_URL_CN
-        else:
-            self.DYSON_API_URL = DYSON_API_URL
         login = requests.post(
             "https://{0}/v1/userregistration/authenticate?country={1}".format(
-                self.DYSON_API_URL, self._country), request_body, verify=False)
+                self._dyson_api_url, self._country),
+            request_body,
+            verify=False
+        )
         # pylint: disable=no-member
         if login.status_code == requests.codes.ok:
             json_response = login.json()
@@ -73,10 +76,10 @@ class DysonAccount:
         if self._logged:
             device_response = requests.get(
                 "https://{0}/v1/provisioningservice/manifest".format(
-                    self.DYSON_API_URL), verify=False, auth=self._auth)
+                    self._dyson_api_url), verify=False, auth=self._auth)
             device_v2_response = requests.get(
                 "https://{0}/v2/provisioningservice/manifest".format(
-                    self.DYSON_API_URL), verify=False, auth=self._auth)
+                    self._dyson_api_url), verify=False, auth=self._auth)
             devices = []
             for device in device_response.json():
                 if is_360_eye_device(device):

--- a/libpurecool/dyson.py
+++ b/libpurecool/dyson.py
@@ -22,6 +22,7 @@ from .exceptions import DysonNotLoggedException
 _LOGGER = logging.getLogger(__name__)
 
 DYSON_API_URL = "appapi.cp.dyson.com"
+DYSON_API_URL_CN = "appapi.cp.dyson.cn"
 
 
 class DysonAccount:
@@ -50,9 +51,13 @@ class DysonAccount:
             "Email": self._email,
             "Password": self._password
         }
+        if self._country == "CN":
+            self.DYSON_API_URL = DYSON_API_URL_CN
+        else:
+            self.DYSON_API_URL = DYSON_API_URL
         login = requests.post(
             "https://{0}/v1/userregistration/authenticate?country={1}".format(
-                DYSON_API_URL, self._country), request_body, verify=False)
+                self.DYSON_API_URL, self._country), request_body, verify=False)
         # pylint: disable=no-member
         if login.status_code == requests.codes.ok:
             json_response = login.json()
@@ -68,10 +73,10 @@ class DysonAccount:
         if self._logged:
             device_response = requests.get(
                 "https://{0}/v1/provisioningservice/manifest".format(
-                    DYSON_API_URL), verify=False, auth=self._auth)
+                    self.DYSON_API_URL), verify=False, auth=self._auth)
             device_v2_response = requests.get(
                 "https://{0}/v2/provisioningservice/manifest".format(
-                    DYSON_API_URL), verify=False, auth=self._auth)
+                    self.DYSON_API_URL), verify=False, auth=self._auth)
             devices = []
             for device in device_response.json():
                 if is_360_eye_device(device):


### PR DESCRIPTION
For Chinese accounts, Dyson has a different API endpoint at
appapi.cp.dyson.cn, and the one ending with "com" won't work.
This patch add an extra check for CN accounts and redirect the call to
the other API endpoint. It's also easier to add more exceptions (if any)
in the future.
The new API endpoint is proven to be official as the Dyson app uses it.