### PR TITLE
Add auto connect to 360 eye

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ main/
 docs/_build
 README.rst
 .vscode
+venv/

--- a/libpurecool/dyson_360_eye.py
+++ b/libpurecool/dyson_360_eye.py
@@ -17,6 +17,20 @@ _LOGGER = logging.getLogger(__name__)
 class Dyson360Eye(DysonDevice):
     """Dyson 360 Eye device."""
 
+    def auto_connect(self, timeout=5, retry=15):
+        """Try to connect to device using mDNS.
+
+        :param timeout: Timeout
+        :param retry: Max retry
+        :return: True if connected, else False
+        """
+        return self._auto_connect("_360eye_mqtt._tcp.local.", timeout, retry)
+
+    @staticmethod
+    def _device_serial_from_name(name):
+        """Get device serial from mDNS name."""
+        return (name.split(".")[0]).split("-", 1)[1]
+
     def connect(self, device_ip, device_port=DEFAULT_PORT):
         """Try to connect to device.
 
@@ -27,6 +41,10 @@ class Dyson360Eye(DysonDevice):
         self._network_device = NetworkDevice(self._name, device_ip,
                                              device_port)
 
+        return self._mqtt_connect()
+
+    def _mqtt_connect(self):
+        """Connect to the MQTT broker."""
         self._mqtt = mqtt.Client(userdata=self, protocol=3)
         self._mqtt.username_pw_set(self._serial, self._credentials)
         self._mqtt.on_message = self.on_message

--- a/libpurecool/dyson_360_eye.py
+++ b/libpurecool/dyson_360_eye.py
@@ -7,7 +7,7 @@ import datetime
 
 import paho.mqtt.client as mqtt
 
-from .dyson_device import DysonDevice, NetworkDevice, DEFAULT_PORT
+from .dyson_device import DysonDevice
 from .utils import printable_fields
 from .const import PowerMode, Dyson360EyeMode, Dyson360EyeCommand
 
@@ -30,18 +30,6 @@ class Dyson360Eye(DysonDevice):
     def _device_serial_from_name(name):
         """Get device serial from mDNS name."""
         return (name.split(".")[0]).split("-", 1)[1]
-
-    def connect(self, device_ip, device_port=DEFAULT_PORT):
-        """Try to connect to device.
-
-        :param device_ip: Device IP address
-        :param device_port: Device Port (default: 1883)
-        :return: True if connected, else False
-        """
-        self._network_device = NetworkDevice(self._name, device_ip,
-                                             device_port)
-
-        return self._mqtt_connect()
 
     def _mqtt_connect(self):
         """Connect to the MQTT broker."""

--- a/libpurecool/dyson_device.py
+++ b/libpurecool/dyson_device.py
@@ -184,19 +184,16 @@ class DysonDevice:
     @abc.abstractmethod
     def _mqtt_connect(self):
         """Connect to the MQTT broker."""
-        return
 
     @staticmethod
     @abc.abstractmethod
     def _device_serial_from_name(name):
         """Get device serial from mDNS name."""
-        return
 
     @property
     @abc.abstractmethod
     def status_topic(self):
         """MQTT status topic."""
-        return
 
     @property
     def command_topic(self):

--- a/libpurecool/dyson_device.py
+++ b/libpurecool/dyson_device.py
@@ -146,7 +146,6 @@ class DysonDevice:
         """Set function called when device is connected."""
         self._connection_queue.put_nowait(connected)
 
-    @abc.abstractmethod
     def connect(self, device_ip, device_port=DEFAULT_PORT):
         """Connect to the device using ip address.
 
@@ -154,7 +153,10 @@ class DysonDevice:
         :param device_port: Device Port (default: 1883)
         :return: True if connected, else False
         """
-        return
+        self._network_device = NetworkDevice(self._name, device_ip,
+                                             device_port)
+
+        return self._mqtt_connect()
 
     def _auto_connect(self, type_, timeout=5, retry=15):
         """Try to connect to device using mDNS."""
@@ -178,6 +180,11 @@ class DysonDevice:
             _LOGGER.error("Unable to connect to device %s", self._serial)
             return False
         return self._mqtt_connect()
+
+    @abc.abstractmethod
+    def _mqtt_connect(self):
+        """Connect to the MQTT broker."""
+        return
 
     @staticmethod
     @abc.abstractmethod

--- a/libpurecool/dyson_pure_cool_link.py
+++ b/libpurecool/dyson_pure_cool_link.py
@@ -14,7 +14,7 @@ import paho.mqtt.client as mqtt
 from .dyson_pure_state_v2 import \
     DysonEnvironmentalSensorV2State, DysonPureCoolV2State, \
     DysonPureHotCoolV2State
-from .dyson_device import DysonDevice, NetworkDevice, DEFAULT_PORT
+from .dyson_device import DysonDevice
 from .utils import printable_fields, support_heating, is_pure_cool_v2, \
     support_heating_v2
 from .dyson_pure_state import DysonPureHotCoolState, DysonPureCoolState, \
@@ -89,18 +89,6 @@ class DysonPureCoolLink(DysonDevice):
     def _device_serial_from_name(name):
         """Get device serial from mDNS name."""
         return (name.split(".")[0]).split("_")[1]
-
-    def connect(self, device_ip, device_port=DEFAULT_PORT):
-        """Connect to the device using ip address.
-
-        :param device_ip: Device IP address
-        :param device_port: Device Port (default: 1883)
-        :return: True if connected, else False
-        """
-        self._network_device = NetworkDevice(self._name, device_ip,
-                                             device_port)
-
-        return self._mqtt_connect()
 
     def _mqtt_connect(self):
         """Connect to the MQTT broker."""

--- a/tests/test_360_eye.py
+++ b/tests/test_360_eye.py
@@ -4,9 +4,10 @@ from unittest import mock
 from unittest.mock import Mock
 import json
 
-from libpurecool.dyson_360_eye import Dyson360Eye, NetworkDevice, \
+from libpurecool.dyson_360_eye import Dyson360Eye, \
     Dyson360EyeState, Dyson360EyeMapGlobal, Dyson360EyeMapData, \
     Dyson360EyeMapGrid, Dyson360EyeTelemetryData, Dyson360Goodbye
+from libpurecool.dyson_device import NetworkDevice
 from libpurecool.const import PowerMode, Dyson360EyeMode
 
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,0 +1,68 @@
+from libpurecool.dyson_360_eye import Dyson360Eye
+from paho.mqtt.client import Client
+import pytest
+import socket
+from libpurecool.zeroconf import ServiceInfo, Zeroconf
+from unittest import mock
+from unittest.mock import MagicMock
+import paho.mqtt.client as mqtt
+
+from libpurecool.dyson_pure_cool_link import DysonPureCoolLink
+
+IP_ADDRESS = "192.168.1.2"
+SERIAL = "XXX-XX-XXXXXXXX"
+
+def _mocked_zeroconf():
+    def _get_service_info(*args):
+        service_info = MagicMock(spec=ServiceInfo)
+        service_info.address = socket.inet_aton(IP_ADDRESS)
+        service_info.port = 1883
+        return service_info
+
+    zeroconf = MagicMock(spec=Zeroconf)
+    zeroconf.get_service_info = MagicMock(side_effect=_get_service_info)
+    return zeroconf
+
+def _get_mocked_service_browser(serial):
+    def _mocked_service_browser(zeroconf, type, listener):
+        listener.add_service(zeroconf, type, f"{serial}.{type}")
+    return _mocked_service_browser
+
+
+@pytest.mark.parametrize(
+    "device_class,serial_prefix",
+    [
+        (DysonPureCoolLink, "PURE-COOL-LINK_"),
+        (Dyson360Eye, "360EYE-"),
+    ]
+)
+def test_auto_connect(device_class, serial_prefix):
+    with mock.patch(
+        'libpurecool.dyson_device.ServiceBrowser',
+        side_effect=_get_mocked_service_browser(serial_prefix + SERIAL),
+    ), mock.patch(
+        'libpurecool.dyson_device.Zeroconf',
+        side_effect=_mocked_zeroconf,
+    ), mock.patch('paho.mqtt.client.Client'):
+        device = device_class({
+            "Active": True,
+            "Serial": SERIAL,
+            "Name": "device-1",
+            "ScaleUnit": "SU01",
+            "Version": "21.03.08",
+            "LocalCredentials": "1/aJ5t52WvAfn+z+fjDuef86kQDQPefbQ6/"
+                                "70ZGysII1Ke1i0ZHakFH84DZuxsSQ4KTT2v"
+                                "bCm7uYeTORULKLKQ==",
+            "AutoUpdate": True,
+            "NewVersionAvailable": False,
+            "ProductType": "475"
+        })
+        device.state_data_available()
+        if hasattr(device, "sensor_data_available"):
+            device.sensor_data_available()
+        device.connection_callback(True)
+        connected = device.auto_connect()
+        assert connected is True
+        assert device.state is None
+        if hasattr(device, "disconnect"):
+            device.disconnect()

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,16 +1,15 @@
 from libpurecool.dyson_360_eye import Dyson360Eye
-from paho.mqtt.client import Client
 import pytest
 import socket
 from libpurecool.zeroconf import ServiceInfo, Zeroconf
 from unittest import mock
 from unittest.mock import MagicMock
-import paho.mqtt.client as mqtt
 
 from libpurecool.dyson_pure_cool_link import DysonPureCoolLink
 
 IP_ADDRESS = "192.168.1.2"
 SERIAL = "XXX-XX-XXXXXXXX"
+
 
 def _mocked_zeroconf():
     def _get_service_info(*args):
@@ -23,9 +22,10 @@ def _mocked_zeroconf():
     zeroconf.get_service_info = MagicMock(side_effect=_get_service_info)
     return zeroconf
 
+
 def _get_mocked_service_browser(serial):
     def _mocked_service_browser(zeroconf, type, listener):
-        listener.add_service(zeroconf, type, f"{serial}.{type}")
+        listener.add_service(zeroconf, type, "{}.{}".format(serial, type))
     return _mocked_service_browser
 
 

--- a/tests/test_libpurecoollink.py
+++ b/tests/test_libpurecoollink.py
@@ -240,9 +240,11 @@ class TestLibPureCoolLink(unittest.TestCase):
 
     @mock.patch('socket.inet_ntoa', )
     def test_device_dyson_listener(self, mocked_ntoa):
-        listener = DysonPureCoolLink.DysonDeviceListener('serial-1',
-                                                         on_add_device,
-                                                         device_serial_from_name)
+        listener = DysonPureCoolLink.DysonDeviceListener(
+            'serial-1',
+            on_add_device,
+            device_serial_from_name
+        )
         zeroconf = Mock()
         listener.remove_service(zeroconf, "ptype", "serial-1")
         info = Mock()

--- a/tests/test_libpurecoollink.py
+++ b/tests/test_libpurecoollink.py
@@ -103,6 +103,10 @@ def on_add_device(network_device):
     pass
 
 
+def device_serial_from_name(name):
+    return (name.split(".")[0]).split("_")[1]
+
+
 class TestLibPureCoolLink(unittest.TestCase):
     def setUp(self):
         pass
@@ -237,7 +241,8 @@ class TestLibPureCoolLink(unittest.TestCase):
     @mock.patch('socket.inet_ntoa', )
     def test_device_dyson_listener(self, mocked_ntoa):
         listener = DysonPureCoolLink.DysonDeviceListener('serial-1',
-                                                         on_add_device)
+                                                         on_add_device,
+                                                         device_serial_from_name)
         zeroconf = Mock()
         listener.remove_service(zeroconf, "ptype", "serial-1")
         info = Mock()


### PR DESCRIPTION
360 Eye vacuums uses `_360eye_mqtt._tcp.local.` instead of `_dyson_mqtt._tcp.local.` for mDNS discovery. This PR adds auto connect support to 360 Eye vacuums.