### PR TITLE
Release v0.6.4

### DIFF
--- a/RELEASES.rst
+++ b/RELEASES.rst
@@ -1,3 +1,11 @@
+Version 0.6.4
+~~~~~~~~~~~~~
+
+:Date:
+    2020/11/29
+
+    - Fix changes to Dyson API to prevent script crash (googanhiem)
+
 Version 0.6.3
 ~~~~~~~~~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ PROJECT_CLASSIFIERS = [
 
 setup(
     name="libpurecool",
-    version="0.6.3",
+    version="0.6.4",
     license="Apache License 2.0",
     url="http://libpurecool.readthedocs.io",
     download_url="https://github.com/etheralm/libpurecool",


### PR DESCRIPTION
To include #29 and #27

Would love to get this released so I can update my HomeAssistant instance!

(Just seen [this comment](https://github.com/etheralm/libpurecool/issues/28#issuecomment-734942743) - I'm not familiar with the pypi release process, but I hope this saves you a bit of time. Thanks for your open source work ❤️ )