### PR TITLE
Set state and sensor data earlier

### DIFF
--- a/libpurecool/dyson_360_eye.py
+++ b/libpurecool/dyson_360_eye.py
@@ -113,9 +113,9 @@ class Dyson360Eye(DysonDevice):
         device_msg = None
         if Dyson360EyeState.is_state_message(payload):
             device_msg = Dyson360EyeState(payload)
+            userdata.state = device_msg
             if not userdata.device_available:
                 userdata.state_data_available()
-            userdata.state = device_msg
         elif Dyson360EyeMapGlobal.is_map_global(payload):
             device_msg = Dyson360EyeMapGlobal(payload)
         elif Dyson360EyeTelemetryData.is_telemetry_data(payload):

--- a/libpurecool/dyson_pure_cool_link.py
+++ b/libpurecool/dyson_pure_cool_link.py
@@ -93,9 +93,9 @@ class DysonPureCoolLink(DysonDevice):
                 device_msg = DysonPureCoolV2State(payload)
             else:
                 device_msg = DysonPureCoolState(payload)
+            userdata.state = device_msg
             if not userdata.device_available:
                 userdata.state_data_available()
-            userdata.state = device_msg
             for function in userdata.callback_message:
                 function(device_msg)
         elif DysonEnvironmentalSensorState.is_environmental_state_message(
@@ -104,9 +104,9 @@ class DysonPureCoolLink(DysonDevice):
                 device_msg = DysonEnvironmentalSensorV2State(payload)
             else:
                 device_msg = DysonEnvironmentalSensorState(payload)
+            userdata.environmental_state = device_msg
             if not userdata.device_available:
                 userdata.sensor_data_available()
-            userdata.environmental_state = device_msg
             for function in userdata.callback_message:
                 function(device_msg)
         else:


### PR DESCRIPTION
Currently the state and sensor data is set after the `_state_data_available` and `_sensor_data_available` are enqueued, which means it is possible that the data is actually not ready when the `_mqtt_connect` blocking ends. This PR moves the data assignments earlier, right before the enqueue operations, to solve this.