### PR TITLE
Add call to account status endpoint before attempting to login to fix authentication.

### DIFF
--- a/libpurecool/dyson.py
+++ b/libpurecool/dyson.py
@@ -54,7 +54,9 @@ class DysonAccount:
                       "dyson are using a self signed certificate.")
         # Must first check account status
         accountstatus = requests.get(
-            "https://{0}/v1/userregistration/userstatus".format(self._dyson_api_url),
+            "https://{0}/v1/userregistration/userstatus".format(
+                self._dyson_api_url
+            ),
             params={"country": self._country, "email": self._email},
             headers=self._headers,
             verify=False,

--- a/libpurecool/dyson.py
+++ b/libpurecool/dyson.py
@@ -41,10 +41,7 @@ class DysonAccount:
         self._country = country
         self._logged = False
         self._auth = None
-        self._headers = {
-            'User-Agent': DYSON_API_USER_AGENT,
-            'Content-Type': 'application/json'
-        }
+        self._headers = {'User-Agent': DYSON_API_USER_AGENT}
         if country == "CN":
             self._dyson_api_url = DYSON_API_URL_CN
         else:
@@ -57,10 +54,11 @@ class DysonAccount:
                       "dyson are using a self signed certificate.")
         # Must first check account status
         accountstatus = requests.get(
-            "https://{0}/v1/userregistration/userstatus?country={1}&email={2}".format(
-                self._dyson_api_url, self._country, self._email),
+            "https://{0}/v1/userregistration/userstatus".format(self._dyson_api_url),
+            params={"country": self._country, "email": self._email},
             headers=self._headers,
-            verify=False)
+            verify=False,
+        )
         # pylint: disable=no-member
         if accountstatus.status_code == requests.codes.ok:
             json_status = accountstatus.json()

--- a/libpurecool/dyson.py
+++ b/libpurecool/dyson.py
@@ -54,7 +54,7 @@ class DysonAccount:
                       "dyson are using a self signed certificate.")
         
         #Must first check account status
-        accountstatus = requests.get(f"https://{self._dyson_api_url}/v1/userregistration/userstatus?country={self._country}&email={self._email}")
+        accountstatus = requests.get(f"https://{self._dyson_api_url}/v1/userregistration/userstatus?country={self._country}&email={self._email}", verify=False)
         if accountstatus.status_code == requests.codes.ok:
             json_status = accountstatus.json()
             if json_status['accountStatus'] != "ACTIVE":

--- a/libpurecool/dyson.py
+++ b/libpurecool/dyson.py
@@ -52,6 +52,18 @@ class DysonAccount:
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         _LOGGER.debug("Disabling insecure request warnings since "
                       "dyson are using a self signed certificate.")
+        
+        #Must first check account status
+        accountstatus = requests.get(f"https://{self._dyson_api_url}/v1/userregistration/userstatus?country={self._country}&email={self._email}")
+        if accountstatus.status_code == requests.codes.ok:
+            json_status = accountstatus.json()
+            if json_status['accountStatus'] != "ACTIVE":
+                #The account is not active
+                self._logged = False
+                return self._logged
+        else:
+            self._logged = False
+            return self._logged
 
         request_body = {
             "Email": self._email,

--- a/libpurecool/dyson.py
+++ b/libpurecool/dyson.py
@@ -41,7 +41,10 @@ class DysonAccount:
         self._country = country
         self._logged = False
         self._auth = None
-        self._headers = {'User-Agent': DYSON_API_USER_AGENT, 'Content-Type': 'application/json'}
+        self._headers = {
+            'User-Agent': DYSON_API_USER_AGENT,
+            'Content-Type': 'application/json'
+        }
         if country == "CN":
             self._dyson_api_url = DYSON_API_URL_CN
         else:
@@ -52,13 +55,17 @@ class DysonAccount:
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         _LOGGER.debug("Disabling insecure request warnings since "
                       "dyson are using a self signed certificate.")
-        
-        #Must first check account status
-        accountstatus = requests.get(f"https://{self._dyson_api_url}/v1/userregistration/userstatus?country={self._country}&email={self._email}", headers=self._headers, verify=False)
+        # Must first check account status
+        accountstatus = requests.get(
+            "https://{0}/v1/userregistration/userstatus?country={1}&email={2}".format(
+                self._dyson_api_url, self._country, self._email),
+            headers=self._headers,
+            verify=False)
+        # pylint: disable=no-member
         if accountstatus.status_code == requests.codes.ok:
             json_status = accountstatus.json()
             if json_status['accountStatus'] != "ACTIVE":
-                #The account is not active
+                # The account is not active
                 self._logged = False
                 return self._logged
         else:

--- a/libpurecool/dyson.py
+++ b/libpurecool/dyson.py
@@ -41,7 +41,7 @@ class DysonAccount:
         self._country = country
         self._logged = False
         self._auth = None
-        self._headers = {'User-Agent': DYSON_API_USER_AGENT}
+        self._headers = {'User-Agent': DYSON_API_USER_AGENT, 'Content-Type': 'application/json'}
         if country == "CN":
             self._dyson_api_url = DYSON_API_URL_CN
         else:
@@ -54,7 +54,7 @@ class DysonAccount:
                       "dyson are using a self signed certificate.")
         
         #Must first check account status
-        accountstatus = requests.get(f"https://{self._dyson_api_url}/v1/userregistration/userstatus?country={self._country}&email={self._email}", verify=False)
+        accountstatus = requests.get(f"https://{self._dyson_api_url}/v1/userregistration/userstatus?country={self._country}&email={self._email}", headers=self._headers, verify=False)
         if accountstatus.status_code == requests.codes.ok:
             json_status = accountstatus.json()
             if json_status['accountStatus'] != "ACTIVE":
@@ -73,7 +73,7 @@ class DysonAccount:
             "https://{0}/v1/userregistration/authenticate?country={1}".format(
                 self._dyson_api_url, self._country),
             headers=self._headers,
-            data=request_body,
+            json=request_body,
             verify=False
         )
         # pylint: disable=no-member

--- a/tests/test_dyson_account.py
+++ b/tests/test_dyson_account.py
@@ -4,12 +4,17 @@ from unittest import mock
 
 from libpurecool.dyson_pure_cool import DysonPureCool
 from libpurecool.dyson_pure_hotcool import DysonPureHotCool
-from libpurecool.dyson import DysonAccount, DysonPureCoolLink, \
-    DysonPureHotCoolLink, Dyson360Eye, DysonNotLoggedException, \
-    DYSON_API_USER_AGENT
+from libpurecool.dyson import (
+    DysonAccount,
+    DysonPureCoolLink,
+    DysonPureHotCoolLink,
+    Dyson360Eye,
+    DysonNotLoggedException,
+    DYSON_API_USER_AGENT,
+)
 
-API_HOST = 'appapi.cp.dyson.com'
-API_CN_HOST = 'appapi.cp.dyson.cn'
+API_HOST = "appapi.cp.dyson.com"
+API_CN_HOST = "appapi.cp.dyson.cn"
 
 
 class MockResponse:
@@ -22,19 +27,21 @@ class MockResponse:
 
 
 def _mocked_login_post_failed(*args, **kwargs):
-    url = 'https://{0}{1}?{2}={3}'.format(API_HOST,
-                                          '/v1/userregistration/authenticate',
-                                          'country',
-                                          'language')
-    payload = {'Password': 'password', 'Email': 'email'}
-    if args[0] == url and kwargs['data'] == payload and \
-            kwargs['headers'] == {'User-Agent': DYSON_API_USER_AGENT}:
-        return MockResponse({
-            'Account': 'account',
-            'Password': 'password'
-        }, 401)
+    url = "https://{0}{1}?{2}={3}".format(
+        API_HOST, "/v1/userregistration/authenticate", "country", "language"
+    )
+    payload = {"Password": "password", "Email": "email"}
+    if (
+        args[0] == url
+        and kwargs["data"] == payload
+        and kwargs["headers"] == {"User-Agent": DYSON_API_USER_AGENT}
+    ):
+        return MockResponse(
+            {"Account": "account", "Password": "password"},
+            401)
     else:
         raise Exception("Unknown call")
+
 
 def _mock_gets(*args, **kwargs):
     if "provisioningservice" in args[0]:
@@ -42,76 +49,71 @@ def _mock_gets(*args, **kwargs):
     else:
         return _mocked_status_get(*args, **kwargs)
 
+
 def _mocked_status_get(*args, **kwargs):
-    url = 'https://{0}{1}'.format(API_HOST,
-                                          '/v1/userregistration/userstatus')
+    url = "https://{0}{1}".format(API_HOST, "/v1/userregistration/userstatus")
     params = {"country": "language", "email": "email"}
-    if args[0] == url and kwargs['params'] == params:
-        return MockResponse({
-            'accountStatus': 'ACTIVE'
-        })
+    if args[0] == url and kwargs["params"] == params:
+        return MockResponse({"accountStatus": "ACTIVE"})
     else:
         raise Exception("Unknown call")
+
 
 def _mocked_status_get_cn(*args, **kwargs):
-    url = 'https://{0}{1}'.format(API_CN_HOST,
-                                          '/v1/userregistration/userstatus')
+    url = "https://{0}{1}".format(API_CN_HOST,
+                                  "/v1/userregistration/userstatus")
     params = {"country": "CN", "email": "email"}
-    if args[0] == url and kwargs['params'] == params:
-        return MockResponse({
-            'accountStatus': 'ACTIVE'
-        })
+    if args[0] == url and kwargs["params"] == params:
+        return MockResponse(
+            {"accountStatus": "ACTIVE"}
+            )
     else:
         raise Exception("Unknown call")
+
 
 def _mocked_status_get_failed(*args, **kwargs):
-    url = 'https://{0}{1}'.format(API_HOST,
-                                          '/v1/userregistration/userstatus')
+    url = "https://{0}{1}".format(API_HOST, "/v1/userregistration/userstatus")
     params = {"country": "language", "email": "email"}
-    if args[0] == url and kwargs['params'] == params:
-        return MockResponse({
-            'accountStatus': 'INACTIVE'
-        })
+    if args[0] == url and kwargs["params"] == params:
+        return MockResponse({"accountStatus": "INACTIVE"})
     else:
         raise Exception("Unknown call")
 
+
 def _mocked_login_post(*args, **kwargs):
-    url = 'https://{0}{1}?{2}={3}'.format(API_HOST,
-                                          '/v1/userregistration/authenticate',
-                                          'country',
-                                          'language')
-    payload = {'Password': 'password', 'Email': 'email'}
-    if args[0] == url and kwargs['json'] == payload and \
-            kwargs['headers'] == {'User-Agent': DYSON_API_USER_AGENT}:
-        return MockResponse({
-            'Account': 'account',
-            'Password': 'password'
-        })
+    url = "https://{0}{1}?{2}={3}".format(
+        API_HOST, "/v1/userregistration/authenticate", "country", "language"
+    )
+    payload = {"Password": "password", "Email": "email"}
+    if (
+        args[0] == url
+        and kwargs["json"] == payload
+        and kwargs["headers"] == {"User-Agent": DYSON_API_USER_AGENT}
+    ):
+        return MockResponse({"Account": "account", "Password": "password"})
     else:
         raise Exception("Unknown call")
 
 
 def _mocked_login_post_cn(*args, **kwargs):
-    url = 'https://{0}{1}?{2}={3}'.format(API_CN_HOST,
-                                          '/v1/userregistration/authenticate',
-                                          'country',
-                                          'CN')
-    payload = {'Password': 'password', 'Email': 'email'}
-    if args[0] == url and kwargs['json'] == payload and \
-            kwargs['headers'] == {'User-Agent': DYSON_API_USER_AGENT}:
-        return MockResponse({
-            'Account': 'account',
-            'Password': 'password'
-        })
+    url = "https://{0}{1}?{2}={3}".format(
+        API_CN_HOST, "/v1/userregistration/authenticate", "country", "CN"
+    )
+    payload = {"Password": "password", "Email": "email"}
+    if (
+        args[0] == url
+        and kwargs["json"] == payload
+        and kwargs["headers"] == {"User-Agent": DYSON_API_USER_AGENT}
+    ):
+        return MockResponse({"Account": "account", "Password": "password"})
     else:
         raise Exception("Unknown call")
 
 
 def _mocked_list_devices(*args, **kwargs):
-    url = 'https://{0}{1}'.format(API_HOST,
-                                  '/v1/provisioningservice/manifest')
-    url_v2 = 'https://{0}{1}'.format(API_HOST,
-                                     '/v2/provisioningservice/manifest')
+    url = "https://{0}{1}".format(API_HOST, "/v1/provisioningservice/manifest")
+    url_v2 = "https://{0}{1}".format(API_HOST,
+                                     "/v2/provisioningservice/manifest")
 
     if args[0] == url:
         return MockResponse(
@@ -123,11 +125,11 @@ def _mocked_list_devices(*args, **kwargs):
                     "ScaleUnit": "SU01",
                     "Version": "21.03.08",
                     "LocalCredentials": "1/aJ5t52WvAfn+z+fjDuef86kQDQPefbQ6/"
-                                        "70ZGysII1Ke1i0ZHakFH84DZuxsSQ4KTT2v"
-                                        "bCm7uYeTORULKLKQ==",
+                    "70ZGysII1Ke1i0ZHakFH84DZuxsSQ4KTT2v"
+                    "bCm7uYeTORULKLKQ==",
                     "AutoUpdate": True,
                     "NewVersionAvailable": False,
-                    "ProductType": "475"
+                    "ProductType": "475",
                 },
                 {
                     "Active": False,
@@ -136,11 +138,11 @@ def _mocked_list_devices(*args, **kwargs):
                     "ScaleUnit": "SU02",
                     "Version": "21.02.04",
                     "LocalCredentials": "1/aJ5t52WvAfn+z+fjDuebkH6aWl2H5Q1vCq"
-                                        "CQSjJfENzMefozxWaDoW1yDluPsi09SGT5nW"
-                                        "MxqxtrfkxnUtRQ==",
+                    "CQSjJfENzMefozxWaDoW1yDluPsi09SGT5nW"
+                    "MxqxtrfkxnUtRQ==",
                     "AutoUpdate": False,
                     "NewVersionAvailable": True,
-                    "ProductType": "455"
+                    "ProductType": "455",
                 },
                 {
                     "Active": True,
@@ -149,12 +151,12 @@ def _mocked_list_devices(*args, **kwargs):
                     "ScaleUnit": "SU01",
                     "Version": "21.03.08",
                     "LocalCredentials": "1/aJ5t52WvAfn+z+fjDuef86kQDQPefbQ6/"
-                                        "70ZGysII1Ke1i0ZHakFH84DZuxsSQ4KTT2v"
-                                        "bCm7uYeTORULKLKQ==",
+                    "70ZGysII1Ke1i0ZHakFH84DZuxsSQ4KTT2v"
+                    "bCm7uYeTORULKLKQ==",
                     "AutoUpdate": True,
                     "NewVersionAvailable": False,
-                    "ProductType": "N223"
-                }
+                    "ProductType": "N223",
+                },
             ]
         )
 
@@ -167,33 +169,33 @@ def _mocked_list_devices(*args, **kwargs):
                     "Version": "02.05.001.0006",
                     "AutoUpdate": True,
                     "LocalCredentials": "1/aJ5t52WvAfn+z+fjDuef86kQDQPefbQ6/"
-                                        "70ZGysII1Ke1i0ZHakFH84DZuxsSQ4KTT2v"
-                                        "bCm7uYeTORULKLKQ==",
+                    "70ZGysII1Ke1i0ZHakFH84DZuxsSQ4KTT2v"
+                    "bCm7uYeTORULKLKQ==",
                     "NewVersionAvailable": False,
-                    "ProductType": "438"
+                    "ProductType": "438",
                 },
                 {
                     "Serial": "DB1-US-DBD1231D",
                     "Name": "device-3",
                     "Version": "02.05.001.0006",
                     "LocalCredentials": "1/aJ5t52WvAfn+z+fjDuebkH6aWl2H5Q1vCq"
-                                        "CQSjJfENzMefozxWaDoW1yDluPsi09SGT5nW"
-                                        "MxqxtrfkxnUtRQ==",
+                    "CQSjJfENzMefozxWaDoW1yDluPsi09SGT5nW"
+                    "MxqxtrfkxnUtRQ==",
                     "AutoUpdate": True,
                     "NewVersionAvailable": False,
-                    "ProductType": "520"
+                    "ProductType": "520",
                 },
                 {
                     "Serial": "CB1-US-DBD1231C",
                     "Name": "device-4",
                     "Version": "02.05.001.0006",
                     "LocalCredentials": "1/aJ5t52WvAfn+z+fjDuebkH6aWl2H5Q1vCq"
-                                        "CQSjJfENzMefozxWaDoW1yDluPsi09SGT5nW"
-                                        "MxqxtrfkxnUtRQ==",
+                    "CQSjJfENzMefozxWaDoW1yDluPsi09SGT5nW"
+                    "MxqxtrfkxnUtRQ==",
                     "AutoUpdate": True,
                     "NewVersionAvailable": False,
-                    "ProductType": "527"
-                }
+                    "ProductType": "527",
+                },
             ]
         )
 
@@ -205,8 +207,8 @@ class TestDysonAccount(unittest.TestCase):
     def tearDown(self):
         pass
 
-    @mock.patch('requests.get', side_effect=_mock_gets)
-    @mock.patch('requests.post', side_effect=_mocked_login_post)
+    @mock.patch("requests.get", side_effect=_mock_gets)
+    @mock.patch("requests.post", side_effect=_mocked_login_post)
     def test_connect_account(self, mocked_login, mocked_status):
         dyson_account = DysonAccount("email", "password", "language")
         logged = dyson_account.login()
@@ -214,8 +216,8 @@ class TestDysonAccount(unittest.TestCase):
         self.assertEqual(mocked_login.call_count, 1)
         self.assertTrue(logged)
 
-    @mock.patch('requests.get', side_effect=_mocked_status_get_cn)
-    @mock.patch('requests.post', side_effect=_mocked_login_post_cn)
+    @mock.patch("requests.get", side_effect=_mocked_status_get_cn)
+    @mock.patch("requests.post", side_effect=_mocked_login_post_cn)
     def test_connect_account_cn(self, mocked_login, mocked_status):
         dyson_account = DysonAccount("email", "password", "CN")
         logged = dyson_account.login()
@@ -223,8 +225,8 @@ class TestDysonAccount(unittest.TestCase):
         self.assertEqual(mocked_login.call_count, 1)
         self.assertTrue(logged)
 
-    @mock.patch('requests.get', side_effect=_mocked_status_get_failed)
-    @mock.patch('requests.post', side_effect=_mocked_login_post_failed)
+    @mock.patch("requests.get", side_effect=_mocked_status_get_failed)
+    @mock.patch("requests.post", side_effect=_mocked_login_post_failed)
     def test_connect_account_failed(self, mocked_login, mocked_status):
         dyson_account = DysonAccount("email", "password", "language")
         logged = dyson_account.login()
@@ -236,8 +238,8 @@ class TestDysonAccount(unittest.TestCase):
         dyson_account = DysonAccount("email", "password", "language")
         self.assertRaises(DysonNotLoggedException, dyson_account.devices)
 
-    @mock.patch('requests.get', side_effect=_mock_gets)
-    @mock.patch('requests.post', side_effect=_mocked_login_post)
+    @mock.patch("requests.get", side_effect=_mock_gets)
+    @mock.patch("requests.post", side_effect=_mocked_login_post)
     def test_list_devices(self, mocked_login, mocked_list_devices):
         dyson_account = DysonAccount("email", "password", "language")
         dyson_account.login()
@@ -255,8 +257,8 @@ class TestDysonAccount(unittest.TestCase):
         self.assertTrue(devices[0].active)
         self.assertTrue(devices[0].auto_update)
         self.assertFalse(devices[0].new_version_available)
-        self.assertEqual(devices[0].serial, 'device-id-1')
-        self.assertEqual(devices[0].name, 'device-1')
-        self.assertEqual(devices[0].version, '21.03.08')
-        self.assertEqual(devices[0].product_type, '475')
-        self.assertEqual(devices[0].credentials, 'password1')
+        self.assertEqual(devices[0].serial, "device-id-1")
+        self.assertEqual(devices[0].name, "device-1")
+        self.assertEqual(devices[0].version, "21.03.08")
+        self.assertEqual(devices[0].product_type, "475")
+        self.assertEqual(devices[0].credentials, "password1")


### PR DESCRIPTION
This PR is based on the information form @shenxn here: https://github.com/etheralm/libpurecool/issues/37#issuecomment-777949022

I am also validating the account status in this to avoid unnecessary API calls to Dyson. 